### PR TITLE
Refactor test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,15 @@
   },
   "devDependencies": {
     "backbone": "1.0.x",
-    "mocha": "1.7.x",
+    "mocha": "1.8.x",
     "when": "2.2.x",
-    "q": "0.9.x"
+    "bluebird": "1.2.x",
+    "chai-as-promised": "~4.1.1",
+    "chai": "~1.9.1",
+    "sinon-chai": "~2.5.0",
+    "sinon": "~1.9.1",
+    "sinon-as-promised": "0.0.3",
+    "chai-things": "~0.2.0"
   },
   "dependencies": {},
   "keywords": [


### PR DESCRIPTION
Wanted to do this as part of the process of diagnosing tgriesser/bookshelf#310. Changes include:
- Swapping Q for Bluebird to take advantage of Bluebird's `onPossiblyUnhandledRejection` feature
- Updating to Mocha 1.8.x which has native promise support — you can return a promise to make a test async rather than needing to call the test callback
- Using Chai and Sinon (+ plugins) for more expressive and specific assertions
- General cleanup of tests so that each test covers more specific functionality
