### PR TITLE
Fix mocha version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "backbone": "1.0.x",
-    "mocha": "1.8.x",
+    "mocha": "1.18.x",
     "when": "2.2.x",
     "bluebird": "1.2.x",
     "chai-as-promised": "~4.1.1",


### PR DESCRIPTION
Mocha version was listed as `1.7.x` before and I mistakenly changed that to `1.8.x`. The version is actually `1.18.x`. 
